### PR TITLE
feat(n8n): add public webhook address

### DIFF
--- a/stacks/security/vendor.yml
+++ b/stacks/security/vendor.yml
@@ -1,0 +1,16 @@
+services:
+  cloudflared-n8n:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARE_N8N_TUNNEL_TOKEN:?err}
+    environment:
+      - CLOUDFLARE_N8N_TUNNEL_TOKEN=${CLOUDFLARE_N8N_TUNNEL_TOKEN:?err}
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+    networks:
+      - traefik-public
+
+networks:
+  traefik-public:
+    external: true


### PR DESCRIPTION
This pull request introduces a new service definition for `cloudflared-n8n` in the `stacks/security/vendor.yml` file, enabling secure tunneling for the `n8n` service through Cloudflare.

Infrastructure and networking changes:

* Added a `cloudflared-n8n` service using the `cloudflare/cloudflared:latest` image, configured to run a tunnel with a required token from the environment.
* Defined the `traefik-public` network as an external network and connected the new service to it.