### PR TITLE
Feature/litellm

### DIFF
--- a/stacks/llms/configs/litellm/config.yaml
+++ b/stacks/llms/configs/litellm/config.yaml
@@ -776,12 +776,14 @@ model_list:
   # Vertex AI Qwen Models
   - model_name: qwen3-235b-instruct
     litellm_params:
+      vertex_location: us-south1
       model: vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas
     model_info:
       owned_by: alibaba
 
   - model_name: qwen3-coder-480b-instruct
     litellm_params:
+      vertex_location: us-south1
       model: vertex_ai/qwen/qwen3-coder-480b-a35b-instruct-maas
     model_info:
       owned_by: alibaba

--- a/stacks/main/storage.yml
+++ b/stacks/main/storage.yml
@@ -400,6 +400,40 @@ services:
         - "traefik.tcp.services.supabase-db.loadbalancer.server.port=${SUPABASE_POSTGRES_PORT:-5432}"
         - "traefik.swarm.network=traefik"
 
+  clickhouse:
+    image: clickhouse/clickhouse-server:latest
+    hostname: clickhouse
+    environment:
+      - CLICKHOUSE_USER=${CLICKHOUSE_USER:-clickhouse}
+      - CLICKHOUSE_PASSWORD=${CLICKHOUSE_PASSWORD?err} # TODO: Change to CLICKHOUSE_PASSWORD_FILE
+      - CLICKHOUSE_DB=${CLICKHOUSE_DB:-clickhouse}
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+      - clickhouse-logs:/var/log/clickhouse-server
+    networks:
+      - traefik
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints:
+        - node.labels.storage.manager == true
+      labels:
+        - "traefik.enable=true"
+        # HTTP interface via Traefik
+        - "traefik.http.routers.clickhouse.rule=Host(`clickhouse.${LOCAL_DOMAIN?err}`)"
+        - "traefik.http.routers.clickhouse.entrypoints=websecure"
+        - "traefik.http.routers.clickhouse.tls=true"
+        - "traefik.http.routers.clickhouse.tls.certresolver=le-dns"
+        - "traefik.http.services.clickhouse.loadbalancer.server.port=8123"
+        # TCP native protocol via Traefik
+        - "traefik.tcp.routers.clickhouse-native.rule=HostSNI(`service.clickhouse.${LOCAL_DOMAIN?err}`)"
+        - "traefik.tcp.routers.clickhouse-native.entrypoints=host-internal"
+        - "traefik.tcp.routers.clickhouse-native.tls=true"
+        - "traefik.tcp.routers.clickhouse-native.tls.certresolver=le-dns"
+        - "traefik.tcp.services.clickhouse-native.loadbalancer.server.port=9000"
+        - "traefik.swarm.network=traefik"
+
 volumes:
   # DB data volumes cannot be synced, could cause issues with data integrity
   postgres_data: {}
@@ -417,6 +451,18 @@ volumes:
     driver: rclone
     driver_opts:
       remote: "gcs:${GCS_SYNC_STORAGE_BUCKET?err}/supabase/db/config"
+      allow_other: "true"
+      vfs_cache_mode: full
+  clickhouse-data:
+    driver: rclone
+    driver_opts:
+      remote: "gcs:${GCS_SYNC_STORAGE_BUCKET?err}/clickhouse/data"
+      allow_other: "true"
+      vfs_cache_mode: full
+  clickhouse-logs:
+    driver: rclone
+    driver_opts:
+      remote: "gcs:${GCS_SYNC_STORAGE_BUCKET?err}/clickhouse/logs"
       allow_other: "true"
       vfs_cache_mode: full
 


### PR DESCRIPTION
This pull request introduces ClickHouse as a new service in the storage stack and makes minor configuration updates for Vertex AI Qwen models. The main focus is on provisioning ClickHouse with persistent cloud-backed storage and secure network access, while also ensuring Qwen models are correctly configured for their deployment region.

**ClickHouse integration:**

* Added a new `clickhouse` service to `stacks/main/storage.yml` with environment variables, persistent volumes for data and logs, and Traefik configuration for both HTTP and native TCP access. The service is restricted to nodes labeled as storage managers.
* Defined two new persistent volumes, `clickhouse-data` and `clickhouse-logs`, using the `rclone` driver to back up ClickHouse data and logs to Google Cloud Storage.

**Vertex AI Qwen model configuration:**

* Updated the `vertex_location` parameter to `us-south1` for both `qwen3-235b-instruct` and `qwen3-coder-480b-instruct` models in `stacks/llms/configs/litellm/config.yaml` to ensure correct regional deployment.